### PR TITLE
[v0.2.0] Fix debug mode script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenized/cordova-plugin-attestation-tokens",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cordova plugin for obtaining attestation tokens from Firebase App Check",
   "cordova": {
     "id": "@tokenized/cordova-plugin-attestation-tokens",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@tokenized/cordova-plugin-attestation-tokens" version="0.1.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@tokenized/cordova-plugin-attestation-tokens" version="0.2.0">
   <name>AttestationTokens</name>
   <description>Cordova plugin for obtaining attestation tokens from Firebase App Check</description>
   <license>MIT</license>

--- a/scripts/debugSwitch.js
+++ b/scripts/debugSwitch.js
@@ -1,6 +1,20 @@
 var fs = require('fs');
 var path = require('path');
 
+function getiOSProjectFolder() {
+  // Find project name in config.xml
+  const config = fs.readFileSync('config.xml').toString();
+  let matches = config.match(/<name>(.*?)<\/name>/i);
+  if (!matches) {
+    matches = config.match(/<name short=".*?">(.*?)<\/name>/i);
+  }
+  if (!matches) {
+    throw new Error('Unable to find project name in config.xml');
+  }
+  const projectName = (matches && matches[1]) || null;
+  return `platforms/ios/${projectName}`;
+}
+
 const editsByPlatform = {
   android: {
     file: 'plugins/@tokenized/cordova-plugin-attestation-tokens/src/android/AttestationTokens.java',
@@ -10,7 +24,10 @@ const editsByPlatform = {
       'firebaseAppCheck.installAppCheckProviderFactory(PlayIntegrityAppCheckProviderFactory.getInstance());',
   },
   ios: {
-    file: 'plugins/@tokenized/cordova-plugin-attestation-tokens/src/ios/AttestationTokens.swift',
+    file: path.join(
+      getiOSProjectFolder(),
+      'Plugins/@tokenized/cordova-plugin-attestation-tokens/AttestationTokens.swift',
+    ),
     debug: 'let providerFactory = AppCheckDebugProviderFactory()',
     release: 'let providerFactory = AttestationTokensAppCheckProviderFactory()',
   },

--- a/scripts/debugSwitch.js
+++ b/scripts/debugSwitch.js
@@ -1,5 +1,5 @@
-var fs = require('fs');
-var path = require('path');
+const fs = require('fs');
+const path = require('path');
 
 function getiOSProjectFolder() {
   // Find project name in config.xml
@@ -17,7 +17,7 @@ function getiOSProjectFolder() {
 
 const editsByPlatform = {
   android: {
-    file: 'plugins/@tokenized/cordova-plugin-attestation-tokens/src/android/AttestationTokens.java',
+    file: 'platforms/android/app/src/main/java/com/tokenized/cordova/attestation_tokens/AttestationTokens.java',
     debug:
       'firebaseAppCheck.installAppCheckProviderFactory(DebugAppCheckProviderFactory.getInstance());',
     release:


### PR DESCRIPTION
Previously the debugSwitch script was modifying the code in the Cordova plugins dir, which only updates the build when you have the plugin installed with symlinks for development. The script has been fixed to modify the code files in the platforms dir where they’re built from.