### PR TITLE
[v0.3.0] Performance improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokenized/cordova-plugin-attestation-tokens",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Cordova plugin for obtaining attestation tokens from Firebase App Check",
   "cordova": {
     "id": "@tokenized/cordova-plugin-attestation-tokens",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@tokenized/cordova-plugin-attestation-tokens" version="0.2.0">
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android" id="@tokenized/cordova-plugin-attestation-tokens" version="0.3.0">
   <name>AttestationTokens</name>
   <description>Cordova plugin for obtaining attestation tokens from Firebase App Check</description>
   <license>MIT</license>


### PR DESCRIPTION
This adds a simple 1-minute cache of the last attestation token request result (success or error), in the plugin’s JavaScript, to avoid the cost of calling across Cordova’s native interface for every REST request